### PR TITLE
Update plugin metadata and add GitHub notification balloons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Automatically fetching data
+- Support for notification balloons
 
 ### Fixed
 - Fix nullable htmlUrl handling in DTO and related logic

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.github.naoyukik.intellijplugingithubnotifications
-pluginName = intellij-plugin-github-notifications
+pluginName = GitHub Notifications
 pluginRepositoryUrl = https://github.com/naoyukik/intellij-plugin-github-notifications
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.1
+pluginVersion = 0.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243
@@ -12,7 +12,7 @@ pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IU
-platformVersion = 2024.3
+platformVersion = 2024.3.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/applicaton/ApiClientWorkflow.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/applicaton/ApiClientWorkflow.kt
@@ -1,7 +1,7 @@
 package com.github.naoyukik.intellijplugingithubnotifications.applicaton
 
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.dto.TableDataDto
-import com.github.naoyukik.intellijplugingithubnotifications.domain.NotificationRepository
+import com.github.naoyukik.intellijplugingithubnotifications.domain.GitHubNotificationRepository
 import com.github.naoyukik.intellijplugingithubnotifications.domain.model.GitHubNotification
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -10,7 +10,7 @@ import java.net.URI
 import java.net.URL
 
 class ApiClientWorkflow(
-    private val repository: NotificationRepository,
+    private val repository: GitHubNotificationRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     companion object {

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/applicaton/NotificationWorkflow.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/applicaton/NotificationWorkflow.kt
@@ -1,0 +1,10 @@
+package com.github.naoyukik.intellijplugingithubnotifications.applicaton
+
+import com.github.naoyukik.intellijplugingithubnotifications.domain.NotificationService
+import com.intellij.openapi.project.Project
+
+class NotificationWorkflow {
+    fun fetchedNotification(project: Project) {
+        NotificationService().fetchedNotification(project, "GitHub Notifications has been updated.")
+    }
+}

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/domain/GitHubNotificationRepository.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/domain/GitHubNotificationRepository.kt
@@ -2,6 +2,6 @@ package com.github.naoyukik.intellijplugingithubnotifications.domain
 
 import com.github.naoyukik.intellijplugingithubnotifications.domain.model.GitHubNotification
 
-interface NotificationRepository {
+interface GitHubNotificationRepository {
     fun fetchNotifications(): List<GitHubNotification>
 }

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/domain/NotificationService.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/domain/NotificationService.kt
@@ -1,0 +1,14 @@
+package com.github.naoyukik.intellijplugingithubnotifications.domain
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+
+class NotificationService {
+    fun fetchedNotification(project: Project, content: String) {
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("GitHub Notifications")
+            .createNotification(content, NotificationType.INFORMATION)
+            .notify(project)
+    }
+}

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/infrastructure/GitHubNotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/infrastructure/GitHubNotificationRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package com.github.naoyukik.intellijplugingithubnotifications.infrastructure
 
-import com.github.naoyukik.intellijplugingithubnotifications.domain.NotificationRepository
+import com.github.naoyukik.intellijplugingithubnotifications.domain.GitHubNotificationRepository
 import com.github.naoyukik.intellijplugingithubnotifications.domain.model.GitHubNotification
 import com.github.naoyukik.intellijplugingithubnotifications.utility.CommandExecutor
 import kotlinx.serialization.json.Json
 
-class NotificationRepositoryImpl : NotificationRepository {
+class GitHubNotificationRepositoryImpl : GitHubNotificationRepository {
     override fun fetchNotifications(): List<GitHubNotification> {
         val commandResult = CommandExecutor.execute(
             listOf(

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/userInterface/GitHubNotificationsToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/userInterface/GitHubNotificationsToolWindowFactory.kt
@@ -3,7 +3,7 @@ package com.github.naoyukik.intellijplugingithubnotifications.userInterface
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.ApiClientWorkflow
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.SettingStateWorkflow
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.dto.TableDataDto
-import com.github.naoyukik.intellijplugingithubnotifications.infrastructure.NotificationRepositoryImpl
+import com.github.naoyukik.intellijplugingithubnotifications.infrastructure.GitHubNotificationRepositoryImpl
 import com.github.naoyukik.intellijplugingithubnotifications.infrastructure.SettingStateRepositoryImpl
 import com.github.naoyukik.intellijplugingithubnotifications.utility.DateTimeHandler
 import com.intellij.icons.AllIcons
@@ -43,7 +43,7 @@ import kotlin.coroutines.CoroutineContext
 
 @Suppress("TooManyFunctions")
 class GitHubNotificationsToolWindowFactory : ToolWindowFactory, DumbAware, CoroutineScope, Disposable {
-    private val apiClientWorkflow = ApiClientWorkflow(NotificationRepositoryImpl())
+    private val apiClientWorkflow = ApiClientWorkflow(GitHubNotificationRepositoryImpl())
     private val settingStateWorkflow = SettingStateWorkflow(SettingStateRepositoryImpl())
     private val coroutineJob = Job()
     private var timer: Timer? = null

--- a/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/userInterface/GitHubNotificationsToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/naoyukik/intellijplugingithubnotifications/userInterface/GitHubNotificationsToolWindowFactory.kt
@@ -1,6 +1,7 @@
 package com.github.naoyukik.intellijplugingithubnotifications.userInterface
 
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.ApiClientWorkflow
+import com.github.naoyukik.intellijplugingithubnotifications.applicaton.NotificationWorkflow
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.SettingStateWorkflow
 import com.github.naoyukik.intellijplugingithubnotifications.applicaton.dto.TableDataDto
 import com.github.naoyukik.intellijplugingithubnotifications.infrastructure.GitHubNotificationRepositoryImpl
@@ -33,7 +34,6 @@ import java.awt.event.MouseEvent
 import java.io.IOException
 import java.net.URI
 import java.net.URISyntaxException
-import java.time.LocalDateTime
 import java.util.Timer
 import javax.swing.JComponent
 import javax.swing.table.DefaultTableModel
@@ -74,7 +74,7 @@ class GitHubNotificationsToolWindowFactory : ToolWindowFactory, DumbAware, Corou
 
         val settingState = settingStateWorkflow.getFetchInterval()
 
-        startAutoRefresh(notificationToolTable, settingState.fetchInterval)
+        startAutoRefresh(notificationToolTable, settingState.fetchInterval, project)
     }
 
     private fun createActionToolbar(actionGroup: DefaultActionGroup, targetComponent: JComponent): ActionToolbar {
@@ -173,14 +173,14 @@ class GitHubNotificationsToolWindowFactory : ToolWindowFactory, DumbAware, Corou
         })
     }
 
-    private fun startAutoRefresh(table: JBTable, minute: Int) {
+    private fun startAutoRefresh(table: JBTable, minute: Int, project: Project) {
         timer = fixedRateTimer(
             name = "GitHubNotificationRefresher",
             initialDelay = 0L,
             period = (minute * 60 * 1000).toLong(),
         ) {
             refreshNotifications(table)
-            println(LocalDateTime.now())
+            NotificationWorkflow().fetchedNotification(project)
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
             groupId="tools"
             instance="com.github.naoyukik.intellijplugingithubnotifications.settings.AppSettingsConfigurable"
             id="preference.GitHubNotifications"/>
-
+        <notificationGroup id="GitHub Notifications"
+                           displayType="BALLOON" />
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
- Rename NotificationRepository to GitHubNotificationRepository
- Add notification balloons for GitHub updates
