### PR TITLE
feat: 検証対象バージョンをsinceとuntilのみに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Support for IntelliJ 2025.3
+- Supported versions expanded from 2024.3
 
 ## [0.14.3] - 2025-05-20
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
@@ -114,7 +115,17 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            val productReleases = ProductReleasesValueSource().get()
+            val reducedProductReleases =
+                if (productReleases.size > 2) {
+                    listOf(productReleases.first(), productReleases.last())
+                } else {
+                    productReleases
+                }
+            reducedProductReleases.forEach { version ->
+                val ideVersion = version.substringAfter('-').ifEmpty { version }
+                create(IntelliJPlatformType.IntellijIdeaUltimate, ideVersion)
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,10 @@ pluginGroup = com.github.naoyukik.intellijplugingithubnotifications
 pluginName = GitHub Notifications
 pluginRepositoryUrl = https://github.com/naoyukik/intellij-plugin-github-notifications
 # SemVer format -> https://semver.org
-pluginVersion=0.14.5
+pluginVersion=0.14.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=244
+pluginSinceBuild=243
 pluginUntilBuild=253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension


### PR DESCRIPTION
## Overview

`plugin.xml` の `idea-version` タグの検証を `since-build` と `until-build` のみに限定します。これにより、サポート範囲のみを検証対象とします。

## Issue number

#343

## Changes

- `since-build` と `until-build` のみを検証するようにロジックを修正。
